### PR TITLE
chore: set example version ref to v0.0.0

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,5 @@
 module "dev" {
-  # source = "github.com/hetznercloud/nomad-dev-env?ref=v0.0.0"
-  source = "../"
+  source = "github.com/hetznercloud/nomad-dev-env?ref=v0.0.0" # x-releaser-pleaser-version
 
   hcloud_token = var.hcloud_token
 }


### PR DESCRIPTION
Set example version ref to v0.0.0, so releaser pleaser can bump it to v0.1.0 on the first release.