### PR TITLE
docs: not an official product warning in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repository provides an easy way to setup a simple Nomad cluster with self-signed certificates on the Hetzner cloud.
 
+> [!WARNING]
+> This project is not an official Hetzner Cloud Integration and is intended to be used internally. There is no backwards-compatibility promise.
+
 ## Requirements
 
 - [Nomad](https://developer.hashicorp.com/nomad/docs/install)


### PR DESCRIPTION
As this is a tool used for internal purposes, we want a warning to indicate there is no official support or backwards-compatibility.